### PR TITLE
Do not define lanbda mutable (boost expects constant)

### DIFF
--- a/soft_token.cpp
+++ b/soft_token.cpp
@@ -656,7 +656,7 @@ void soft_token_t::reset()
         auto public_range = p_->objects
             | filtered(by_attrs({create_object(CKA_CLASS, public_key_c)}))
 //                 | filtered(by_attrs({create_object(AttrSshPublic, bool_true)}))
-            | filtered([&private_key] (const Objects::value_type& pub_key) mutable {
+            | filtered([&private_key] (const Objects::value_type& pub_key) {
                 return is_equal(CKA_MODULUS, pub_key, private_key)
                     || pub_key.second.at(CKA_LABEL).to_string() == (private_key.second.at(CKA_LABEL).to_string() + ".pub");
             });


### PR DESCRIPTION
The change is needed to build with current Fedora 25 with the following packages
```
gcc-6.3.1-1.fc25.x86_64
boost-1.60.0-10.fc25.x86_64
```
In the meantime, license is not clear from this repository (original page http://people.su.se/~lha/ is also gone).